### PR TITLE
Removed extra commas from config.yml

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -69,5 +69,5 @@ collections:
           - {label: "Enable darkmode", name: "enableDarkMode", widget: "boolean"}
           - {label: "Enable search", name: "enableSearch", widget: "boolean"}
           - {label: "Enable contact form", name: "enableContact", widget: "boolean"}
-          - {label: "Enable commments", name: "enableComments", widget: "boolean", , default: false}
-          - {label: "Enable encryption", name: "enableEncryption", widget: "boolean", , default: false}
+          - {label: "Enable commments", name: "enableComments", widget: "boolean", default: false}
+          - {label: "Enable encryption", name: "enableEncryption", widget: "boolean", default: false}


### PR DESCRIPTION
The extra commas in the field settings for enabling comments and encryption result in the following error when accessing the admin URL for NetlifyCMS.

Error loading the CMS configuration
Config Errors:
YAMLSyntaxError: Flow map contains an unexpected , at line 72, column 84:

…Enable commments", name: "enableComments", widget: "boolean", , default: false}
                                                               ^
Check your config.yml file.