### PR TITLE
[#39] FIX: NetlifyCMS using "pages" folder

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -31,7 +31,7 @@ collections:
   # Our pages e.g. About
   - name: "pages"
     label: "Page"
-    folder: "pages"
+    folder: "content/pages"
     create: true # Change to true to allow editors to create new pages
     slug: "{{slug}}"
     fields:


### PR DESCRIPTION
I changed NetlifyCMS config file so that it uses the content/pages folder, as that is the folder where pages are stored (https://spacebook.app/getting-started/content/index.htm).