### PR TITLE
Fix Links in Inline Code & Default Callout Dark Mode; Errant {}; Date/Time Zone

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -139,13 +139,13 @@ module.exports = function(eleventyConfig) {
 
   // Date formatting (human readable)
   eleventyConfig.addFilter("readableDate", dateObj => {
-    return DateTime.fromJSDate(dateObj).toFormat("LLL dd, yyyy");
+    return DateTime.fromJSDate(dateObj).setZone("utc").toFormat("LLL dd, yyyy");
   });
 
   // Date formatting (machine readable)
   eleventyConfig.addFilter("machineDate", dateObj => {
 
-    return DateTime.fromJSDate(dateObj).toFormat("yyyy-MM-dd");
+    return DateTime.fromJSDate(dateObj).setZone("utc").toFormat("yyyy-MM-dd");
   });
 
   // Minify CSS

--- a/_includes/experimental/blog/layouts/blog.njk
+++ b/_includes/experimental/blog/layouts/blog.njk
@@ -5,7 +5,7 @@ permalink: /blog/index.html
 ---
 <div class="flex w-full justify-center">
     <div class="mt-4 px-6 md:px-6 lg:px-8 xl:px-12 w-full max-w-5xl">
-        <div class="wrapper flex justify-between">
+        <div class="flex-wrap justify-between">
              <div class="main  flex flex-col pr-0 prose sm:prose lg:prose-lg xl:prose-md">
                 <article>
 

--- a/_includes/experimental/blog/layouts/post.njk
+++ b/_includes/experimental/blog/layouts/post.njk
@@ -17,7 +17,7 @@ section: post
  
 <div class="flex w-full justify-center">
     <div class="mt-4 px-6 md:px-6 lg:px-8 xl:px-12 w-full max-w-5xl">
-        <div class="wrapper flex justify-between">
+        <div class="flex-wrap justify-between">
             {% if site.enableTOC and toc %} 
             <div class="main flex flex-col pr-0 xl:pr-64 prose sm:prose lg:prose-lg xl:prose-md">
             {% else %}

--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -18,7 +18,7 @@ section: page
  
 <div class="flex w-full justify-center">
     <div class="mt-4 px-6 md:px-6 lg:px-8 xl:px-12 w-full max-w-5xl">
-        <div class="wrapper flex justify-between">
+        <div class="flex-wrap justify-between">
             {% if site.enableTOC and toc %} 
             <div class="main flex flex-col pr-0 xl:pr-64 prose sm:prose lg:prose-lg xl:prose-md">
             {% else %}

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -18,7 +18,7 @@
   .prose a:hover {
     @apply dark:text-gray-500
   }
-  .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 .prose hr, .prose strong {
+  .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 .prose hr, .prose strong, .prose code {
     @apply dark:text-gray-400
   }
   .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
@@ -35,11 +35,9 @@
     @apply list-none -ml-6 !important;
   }
   .prose ul.contains-task-list .task-list-item,
-  .prose ul.spacelog {
-    ::before {
+  .prose ul.spacelog::before {
       @apply hidden !important;
     }
-  }
 
   /* Define blockquotes and some standard callout blocks */
   blockquote {
@@ -49,7 +47,7 @@
     @apply px-8 py-4 mb-4 rounded-lg bg-yellow-50;
   }
   .callout, .callout strong, .callout em {
-    @apply dark:bg-gray-400 dark:text-gray-900;
+    @apply dark:bg-yellow-400 dark:text-gray-900;
   }
   .callout-blue {
     @apply px-8 py-4 mb-4 rounded-lg bg-blue-50;

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -18,14 +18,17 @@
   .prose a:hover {
     @apply dark:text-gray-500
   }
-  .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 .prose hr, .prose strong, .prose code {
+  .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 .prose hr, .prose strong, .prose thead {
     @apply dark:text-gray-400
   }
   .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
     scroll-margin-top: 3.5em;
   }
-  .prose pre code {
-    @apply overflow-x-auto !important 
+  .prose pre {
+    @apply overflow-x-auto !important;
+  }
+  .prose code {
+    @apply dark:text-gray-400 overflow-x-auto !important;
   }
   .prose .footer-nav a {
     @apply no-underline !important

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -34,11 +34,12 @@
   .prose ul.spacelog  {
     @apply list-none -ml-6 !important;
   }
-  .prose ul.contains-task-list .task-list-item,
+  .prose ul.contains-task-list .task-list-item::before {
+      @apply hidden !important;
+    }
   .prose ul.spacelog::before {
       @apply hidden !important;
     }
-
   /* Define blockquotes and some standard callout blocks */
   blockquote {
     @apply rounded-lg p-4 bg-gray-100 dark:bg-gray-500 border-gray-200 border-l-8 dark:border-gray-700;


### PR DESCRIPTION
Fix the following issues:
- In dark mode, inline code is styled in the same font color as background color as documented here in Pull Request #42.
- In dark mode, link is styled in the same font color as the default call box's background color.
- In dark mode, the table header is styled in the same font color as background color as documented here in Issue #33 
- tailwind.css file errant curly brackets {} in one of the .prose elements.
- The dates in pages and posts are off by one day.
- The navigation to and from pages and posts near the footer sometimes do not stretch to full width if the body texts are short and narrow-width.